### PR TITLE
Fixed uninitialised variable bug per MarlinFirmware#23791

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -300,8 +300,8 @@ G29_TYPE GcodeSuite::G29() {
 
         if (!isnan(rx) && !isnan(ry)) {
           // Get nearest i / j from rx / ry
-          i = (rx - bilinear_start.x + 0.5 * abl.gridSpacing.x) / abl.gridSpacing.x;
-          j = (ry - bilinear_start.y + 0.5 * abl.gridSpacing.y) / abl.gridSpacing.y;
+          i = (rx - bbl.get_grid_start().x) / bbl.get_grid_spacing().x + 0.5f;
+          j = (ry - bbl.get_grid_start().y) / bbl.get_grid_spacing().y + 0.5f;
           LIMIT(i, 0, (GRID_MAX_POINTS_X) - 1);
           LIMIT(j, 0, (GRID_MAX_POINTS_Y) - 1);
         }


### PR DESCRIPTION
Although the G29 routine displays all zeroes as part of the process, the Marlin Pull Request says those values remained cached and used in error by the firmware when printing.
This is the entire change on record upstream to correct the bug.

<!--

Submitting a Pull Request

**Bug Description**
In GcodeSuite::G29() in [Marlin/src/gcode/bedlevel/abl/G29.cpp](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.0.x/Marlin/src/gcode/bedlevel/abl/G29.cpp) at line 300 is the following code:

          i = (rx - bilinear_start.x + 0.5 * abl.gridSpacing.x) / abl.gridSpacing.x;
          j = (ry - bilinear_start.y + 0.5 * abl.gridSpacing.y) / abl.gridSpacing.y;
When this code executes, abl.gridSpacing is uninitialised. bilinear_grid_spacing should be used instead.

**Bug Timeline**
It has been in the code since at least 2017.

**Expected behavior**
I expect the X and Y parameters to be converted into equivalent I and J parameters.

**Actual behavior**
The actual behaviour is undefined. The z value for some grid point will be set but not necessarily the one specified.

**Steps to Reproduce**
G28
G29
G29 W X200 Y200 Z2
M420 V
On my 200x200 bed with a 3x3 grid this should result in something like

Bilinear Leveling Grid:
      0      1      2
 0 +0.084 -0.016 +0.039
 1 +0.082 +0.195 -0.038
 2 +0.023 +0.224 +2.000

In reality the 0, 0 value gets set to 2.0 rather than the 2, 2 value.
